### PR TITLE
Mitigate gpsd CVE exposure by making local gpspipe optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ In order to get the most out of this app, even for the "local-only" deployment i
 
 The network mode must be set to "host" to allow direct access to the chrony service that is running on the host. If this is changed to "bridge" or anything else, it will not work as expected.
 
+Local GPS probing from inside the container is optional. The default build installs Chrony tooling only, which avoids shipping Alpine's gpsd package by default. If you need local `gpspipe` support in the container, build with `INSTALL_GPSD_CLIENTS=true`.
+
 # Resource Usage
 Usage is low running either the amd64 or the arm 64 image. Network is near 0% even if you are using the "remote" mode to access a local NTP server on your network.
 

--- a/app.py
+++ b/app.py
@@ -163,8 +163,15 @@ def get_gps():
         
     satellites =[]
     gps_time = "Waiting for lock..."
+    error = None
+    if gps_out and ("Error" in gps_out or "command not found" in gps_out.lower()):
+        error = gps_out
+        if config.get("mode") == "local" and "gpspipe" in gps_out and "not found" in gps_out.lower():
+            error = "Local GPS support is not installed in this image. Rebuild with INSTALL_GPSD_CLIENTS=true to enable gpspipe, or switch to Remote mode."
+            gps_time = "Local GPS support not installed"
+
     try:
-        if gps_out and "Error" not in gps_out:
+        if gps_out and not error:
             for line in gps_out.strip().split('\n'):
                 if not line: continue
                 try:
@@ -176,7 +183,7 @@ def get_gps():
                 except: pass
     except: pass
     
-    return jsonify({"satellites": satellites, "gps_time": gps_time})
+    return jsonify({"satellites": satellites, "gps_time": gps_time, "error": error})
 
 @app.route('/api/clients')
 def get_clients():

--- a/app.py
+++ b/app.py
@@ -164,7 +164,7 @@ def get_gps():
     satellites =[]
     gps_time = "Waiting for lock..."
     error = None
-    if gps_out and ("Error" in gps_out or "command not found" in gps_out.lower()):
+    if gps_out and (gps_out.startswith('Error:') or "command not found" in gps_out.lower()):
         error = gps_out
         if config.get("mode") == "local" and "gpspipe" in gps_out and "not found" in gps_out.lower():
             error = "Local GPS support is not installed in this image. Rebuild with INSTALL_GPSD_CLIENTS=true to enable gpspipe, or switch to Remote mode."

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,9 +2,12 @@
 
 services:
   ntp-dashboard:
-    build: .
+    build:
+      context: .
+      args:
+        INSTALL_GPSD_CLIENTS: "false" # Set to true only if you need local gpspipe inside the container.
     container_name: ntp-dashboard
-    network_mode: "host" # Allows container to query host's chrony/gpsd
+    network_mode: "host" # Allows the container to query host chrony; local gpspipe support is optional.
     volumes:
       - /mnt/Apps/Storage/ntp-docker/templates/config.json:/app/config.json # Persists UI settings
     restart: unless-stopped

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,7 @@ services:
   ntp-dashboard:
     build:
       context: .
+      dockerfile: dockerfile
       args:
         INSTALL_GPSD_CLIENTS: "false" # Set to true only if you need local gpspipe inside the container.
     container_name: ntp-dashboard

--- a/dockerfile
+++ b/dockerfile
@@ -2,9 +2,13 @@ FROM python:3.14-alpine
 
 WORKDIR /app
 
-# 1. Install Alpine's lightweight packages (No Desktop GUI bloat!)
-# We also install GNU grep just to ensure compatibility with our scripts
-RUN apk add --no-cache chrony gpsd-clients grep
+# 1. Install the default local runtime tools
+ARG INSTALL_GPSD_CLIENTS=false
+RUN set -eux; \
+	apk add --no-cache chrony; \
+	if [ "$INSTALL_GPSD_CLIENTS" = "true" ]; then \
+		apk add --no-cache gpsd-clients; \
+	fi
 
 # 2. Download Tailwind CSS locally
 RUN mkdir -p /app/static && wget -q https://cdn.tailwindcss.com/ -O /app/static/tailwindcss.js

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -177,7 +177,15 @@ document.getElementById('configForm').addEventListener('submit', async (e) => {
                     baseGpsTimeMs = null;
                     document.getElementById('gpsTimeDisplay').innerText = d.gps_time || 'GPS unavailable';
                     document.getElementById('satellitesLayer').innerHTML = '';
-                    satTableBody.innerHTML = `<tr><td colspan="5" class="p-4 text-red-500 whitespace-pre-wrap">${d.error}</td></tr>`;
+                    // Render error as plain text to avoid HTML/script injection
+                    satTableBody.innerHTML = '';
+                    const errorRow = document.createElement('tr');
+                    const errorCell = document.createElement('td');
+                    errorCell.colSpan = 5;
+                    errorCell.className = 'p-4 text-red-500 whitespace-pre-wrap';
+                    errorCell.textContent = d.error;
+                    errorRow.appendChild(errorCell);
+                    satTableBody.appendChild(errorRow);
                     satCountEl.innerText = 'Unavailable';
                     sweepTimer = 30;
                     return;

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -170,6 +170,18 @@ document.getElementById('configForm').addEventListener('submit', async (e) => {
             try {
                 const res = await fetch('/api/gps');
                 const d = await res.json();
+                const satTableBody = document.getElementById('satTableBody');
+                const satCountEl = document.getElementById('satCount');
+
+                if (d.error) {
+                    baseGpsTimeMs = null;
+                    document.getElementById('gpsTimeDisplay').innerText = d.gps_time || 'GPS unavailable';
+                    document.getElementById('satellitesLayer').innerHTML = '';
+                    satTableBody.innerHTML = `<tr><td colspan="5" class="p-4 text-red-500 whitespace-pre-wrap">${d.error}</td></tr>`;
+                    satCountEl.innerText = 'Unavailable';
+                    sweepTimer = 30;
+                    return;
+                }
                 
                 // --- CAPTURE THE RAW GPS TIME FOR THE LIVE TICKER ---
                 if (d.gps_time && d.gps_time.includes('T')) {
@@ -216,8 +228,8 @@ document.getElementById('configForm').addEventListener('submit', async (e) => {
                 }
 
                 document.getElementById('satellitesLayer').innerHTML = svgContent;
-                document.getElementById('satTableBody').innerHTML = tableHtml;
-                document.getElementById('satCount').innerText = lockedCount + ' Locked';
+                satTableBody.innerHTML = tableHtml;
+                satCountEl.innerText = lockedCount + ' Locked';
                 sweepTimer = 30;
                 
             } catch(e) {


### PR DESCRIPTION
I noticed a high CVE still in place for the latest release so I decided to work it out with copilot to verify the CVE, locate the issue, and suggest a fix. I did the "leg work" to verify the CVE and provide it to copilot for reference. I also provided the exact package and version that is affected. Copilot decided to remove the dependency for local deployments as it wasn't needed in most cases. It is still an option for deployment but it has to be added manually with a build argument (meaning the image will need to be built from source each time an update is released to keep supporting it. I will be testing a theory after completing the PR and merging to the pre-update-release branch. Then I can do some testing locally before releasing next week.