### PR TITLE
Improve GPS field handling and clean up ignore/config comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /README.md
 /LICENSE
 /requirements.txt
+/.dockerignore
+/data/
+/__pycache__/

--- a/app.py
+++ b/app.py
@@ -181,7 +181,7 @@ def get_ntp():
 @app.route('/api/gps')
 def get_gps():
     config = load_config()
-    cmd = ["timeout 3 gpspipe -w -n 12"]
+    cmd = ["timeout 3 gpspipe -w -n 12 || true"]
     
     if config.get("mode") == "local":
         gps_out = run_commands_local(cmd)[0]
@@ -204,7 +204,8 @@ def get_gps():
             try:
                 data = json.loads(line)
                 if data.get("class") == "SKY":
-                    satellites = data.get("satellites", [])
+                    if "satellites" in data:
+                        satellites = data["satellites"]
                 elif data.get("class") == "TPV" and "time" in data:
                     gps_time = data.get("time")
             except json.JSONDecodeError as e:

--- a/app.py
+++ b/app.py
@@ -181,7 +181,7 @@ def get_ntp():
 @app.route('/api/gps')
 def get_gps():
     config = load_config()
-    cmd = ["timeout 3 gpspipe -w -n 12 || true"]
+    cmd = ["timeout 3 gpspipe -w -n 12"]
     
     if config.get("mode") == "local":
         gps_out = run_commands_local(cmd)[0]

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,9 +9,9 @@ services:
     container_name: ntp-dashboard
     network_mode: "host" # Allows the container to query host chrony; local gpspipe support is optional.
     environment:
-      - LOG_LEVEL=DEBUG # Default level for normal operation
+      - LOG_LEVEL=INFO # Standard runtime logs (recommended default for normal operation)
         # Supported levels:
-        # - DEBUG    # Most verbose (for troubleshooting)
+        # - DEBUG    # Most verbose (for troubleshooting only; may enable Flask debug mode)
         # - INFO     # Standard runtime logs (recommended default)
         # - WARNING  # Warnings and errors only
         # - ERROR    # Errors only

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,7 @@ services:
     container_name: ntp-dashboard
     network_mode: "host" # Allows the container to query host chrony; local gpspipe support is optional.
     environment:
-      - LOG_LEVEL=INFO # Default level for normal operation
+      - LOG_LEVEL=DEBUG # Default level for normal operation
         # Supported levels:
         # - DEBUG    # Most verbose (for troubleshooting)
         # - INFO     # Standard runtime logs (recommended default)


### PR DESCRIPTION
### Changes

* Updated `.gitignore`

  * added `.dockerignore`
  * added `data/`
  * added `__pycache__/`

* Improved GPS parsing in `app.py`

  * replaced direct `data.get("satellites", [])` assignment
  * now checks whether `"satellites"` exists before assigning
  * helps avoid unintentionally overwriting previous/default values when the field is absent

* Refined `compose.yaml` comments

  * clarified the default `LOG_LEVEL=INFO`
  * improved wording for the `DEBUG` log level note