### PR TITLE
Change cron schedule for weekly security check

### DIFF
--- a/.github/workflows/weekly-security-grype.yml
+++ b/.github/workflows/weekly-security-grype.yml
@@ -3,7 +3,7 @@ name: Weekly Security Scan and Remediation
 on:
   schedule:
     # Wednesday 10:00 UTC (~6am ET during DST, ~5am ET during EST)
-    - cron: "0 10 * * 3"
+    - cron: "0 12 * * 3"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Updated the cron schedule to run at 12:00 UTC on Wednesdays instead of 10:00 UTC.