### PR TITLE
fix(web): align PWA icon path and add external link hardening

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -8,7 +8,7 @@
   "theme_color": "#3b82f6",
   "icons":[
     {
-      "src": "/static/images/logo.png",
+      "src": "/static/images/ntp-dashboard-logo.png",
       "sizes": "192x192 512x512",
       "type": "image/png",
       "purpose": "any maskable"

--- a/static/sw.js
+++ b/static/sw.js
@@ -3,7 +3,7 @@ const ASSETS_TO_CACHE =[
     '/',
     '/static/tailwindcss.js',
     '/static/dashboard.js',
-    '/static/images/logo.png',
+    '/static/images/ntp-dashboard-logo.png',
     '/manifest.json'
 ];
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -233,10 +233,10 @@
 
         <!-- Version Footer & Update Notification -->
         <div class="mt-8 flex justify-center items-center text-sm font-mono text-gray-500 dark:text-gray-400">
-            <a href="https://github.com/NightHawkATL/ntp-dashboard" target="_blank" class="hover:text-primary-500 transition-colors">ntp-dashboard</a>
-            <a href="https://github.com/NightHawkATL/ntp-dashboard/releases" target="_blank" id="versionDisplay" class="ml-2 hover:text-primary-500 transition-colors">{{ app_version }}</a>
+            <a href="https://github.com/NightHawkATL/ntp-dashboard" target="_blank" rel="noopener noreferrer" class="hover:text-primary-500 transition-colors">ntp-dashboard</a>
+            <a href="https://github.com/NightHawkATL/ntp-dashboard/releases" target="_blank" rel="noopener noreferrer" id="versionDisplay" class="ml-2 hover:text-primary-500 transition-colors">{{ app_version }}</a>
             
-            <a href="https://github.com/NightHawkATL/ntp-dashboard/releases/latest" target="_blank" id="updateBadge" class="hidden ml-3 px-2 py-0.5 rounded text-xs font-bold bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-400 border border-green-200 dark:border-green-800 animate-pulse hover:bg-green-200 dark:hover:bg-green-900 transition-colors">
+            <a href="https://github.com/NightHawkATL/ntp-dashboard/releases/latest" target="_blank" rel="noopener noreferrer" id="updateBadge" class="hidden ml-3 px-2 py-0.5 rounded text-xs font-bold bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-400 border border-green-200 dark:border-green-800 animate-pulse hover:bg-green-200 dark:hover:bg-green-900 transition-colors">
                 New Update: vX.X.X
             </a>
         </div>


### PR DESCRIPTION
## Why
Fixes two web-facing issues before v0.1.2:
- PWA icon/cache path mismatch
- Missing rel attributes on external links opened in new tabs

## Changes
- Updated manifest icon src to the existing logo file
- Updated service worker cache asset list to the same logo file
- Added rel="noopener noreferrer" to external links with target="_blank"

## Validation
- Verified edited files have no syntax/errors in workspace checks.