### PR TITLE
fix: refresh dashboard data after cache resume

### DIFF
--- a/app.py
+++ b/app.py
@@ -137,6 +137,14 @@ def manifest():
 def service_worker():
     return send_from_directory('static', 'sw.js', mimetype='application/javascript')
 
+@app.after_request
+def set_cache_headers(response):
+    if request.path.startswith('/api/'):
+        response.headers['Cache-Control'] = 'no-store, no-cache, must-revalidate, max-age=0'
+        response.headers['Pragma'] = 'no-cache'
+        response.headers['Expires'] = '0'
+    return response
+
 # --- API Routes ---
 @app.route('/')
 def index(): 

--- a/app.py
+++ b/app.py
@@ -143,6 +143,10 @@ def set_cache_headers(response):
         response.headers['Cache-Control'] = 'no-store, no-cache, must-revalidate, max-age=0'
         response.headers['Pragma'] = 'no-cache'
         response.headers['Expires'] = '0'
+    elif request.path in ('/sw.js', '/manifest.json'):
+        response.headers['Cache-Control'] = 'no-cache, max-age=0, must-revalidate'
+        response.headers['Pragma'] = 'no-cache'
+        response.headers['Expires'] = '0'
     return response
 
 # --- API Routes ---

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -135,7 +135,7 @@ document.getElementById('configForm').addEventListener('submit', async (e) => {
         // 4. NTP Data Polling (2 Seconds)
         async function fetchNTP() {
             try {
-                const res = await fetch('/api/ntp');
+                const res = await fetch('/api/ntp', { cache: 'no-store' });
                 const d = await res.json();
                 
                 const offsetEl = document.getElementById('sysOffset');
@@ -168,7 +168,7 @@ document.getElementById('configForm').addEventListener('submit', async (e) => {
         let sweepTimer = 30;
         async function fetchGPS() {
             try {
-                const res = await fetch('/api/gps');
+                const res = await fetch('/api/gps', { cache: 'no-store' });
                 const d = await res.json();
                 const satTableBody = document.getElementById('satTableBody');
                 const satCountEl = document.getElementById('satCount');
@@ -242,6 +242,11 @@ document.getElementById('configForm').addEventListener('submit', async (e) => {
                 
             } catch(e) {
                 console.error("GPS Fetch Failed", e);
+                baseGpsTimeMs = null;
+                document.getElementById('gpsTimeDisplay').innerText = 'GPS unavailable';
+                document.getElementById('satellitesLayer').innerHTML = '';
+                document.getElementById('satTableBody').innerHTML = '<tr><td colspan="5" class="p-4 text-red-500">Failed to communicate with API.</td></tr>';
+                document.getElementById('satCount').innerText = 'Unavailable';
             }
         }
 
@@ -340,11 +345,42 @@ function renderClientsTable() {
         }, 1000);
 
         // 7. Initialize
+        let ntpIntervalId = null;
+        let gpsIntervalId = null;
+
+        function startPolling() {
+            if (ntpIntervalId === null) {
+                ntpIntervalId = setInterval(fetchNTP, 2000);
+            }
+            if (gpsIntervalId === null) {
+                gpsIntervalId = setInterval(fetchGPS, 30000);
+            }
+        }
+
+        function refreshNow() {
+            fetchNTP();
+            fetchGPS();
+        }
+
         loadUI();
-        fetchNTP();
-        fetchGPS();
-        setInterval(fetchNTP, 2000);
-        setInterval(fetchGPS, 30000);
+        refreshNow();
+        startPolling();
+
+        // Force fresh data when the tab becomes active again.
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'visible') {
+                refreshNow();
+                startPolling();
+            }
+        });
+
+        window.addEventListener('focus', refreshNow);
+        window.addEventListener('pageshow', (event) => {
+            if (event.persisted) {
+                refreshNow();
+            }
+        });
+        window.addEventListener('online', refreshNow);
        
         // 9. Register PWA Service Worker
         if ('serviceWorker' in navigator) {

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -357,7 +357,13 @@ function renderClientsTable() {
             }
         }
 
+        let lastRefreshTime = 0;
+        const REFRESH_DEBOUNCE_MS = 1000;
+
         function refreshNow() {
+            const now = Date.now();
+            if (now - lastRefreshTime < REFRESH_DEBOUNCE_MS) return;
+            lastRefreshTime = now;
             fetchNTP();
             fetchGPS();
         }

--- a/static/sw.js
+++ b/static/sw.js
@@ -12,9 +12,8 @@ self.addEventListener('install', event => {
     event.waitUntil(
         caches.open(CACHE_NAME).then(cache => {
             return cache.addAll(ASSETS_TO_CACHE);
-        })
+        }).then(() => self.skipWaiting())
     );
-    self.skipWaiting();
 });
 
 // Activate event: remove old caches so users receive updated JS/HTML assets

--- a/static/sw.js
+++ b/static/sw.js
@@ -18,12 +18,12 @@ self.addEventListener('install', event => {
 
 // Activate event: remove old caches so users receive updated JS/HTML assets
 self.addEventListener('activate', event => {
-    event.waitUntil(
+    event.waitUntil(Promise.all([
         caches.keys().then(keys => Promise.all(
             keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
-        ))
-    );
-    self.clients.claim();
+        )),
+        self.clients.claim()
+    ]));
 });
 
 // Fetch event: Serve cached files, but ALWAYS fetch fresh data from the API

--- a/static/sw.js
+++ b/static/sw.js
@@ -36,7 +36,7 @@ self.addEventListener('fetch', event => {
     // For navigations (HTML), prefer network so UI/JS updates arrive quickly.
     if (event.request.mode === 'navigate') {
         event.respondWith(
-            fetch(event.request).catch(() => caches.match('/'))
+            fetch(new Request(event.request, { cache: 'no-store' })).catch(() => caches.match('/'))
         );
         return;
     }

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ntp-dash-v1';
+const CACHE_NAME = 'ntp-dash-v2';
 const ASSETS_TO_CACHE =[
     '/',
     '/static/tailwindcss.js',
@@ -14,6 +14,17 @@ self.addEventListener('install', event => {
             return cache.addAll(ASSETS_TO_CACHE);
         })
     );
+    self.skipWaiting();
+});
+
+// Activate event: remove old caches so users receive updated JS/HTML assets
+self.addEventListener('activate', event => {
+    event.waitUntil(
+        caches.keys().then(keys => Promise.all(
+            keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+        ))
+    );
+    self.clients.claim();
 });
 
 // Fetch event: Serve cached files, but ALWAYS fetch fresh data from the API
@@ -21,6 +32,14 @@ self.addEventListener('fetch', event => {
     // We NEVER want to cache the live time/GPS data APIs
     if (event.request.url.includes('/api/')) {
         return; 
+    }
+
+    // For navigations (HTML), prefer network so UI/JS updates arrive quickly.
+    if (event.request.mode === 'navigate') {
+        event.respondWith(
+            fetch(event.request).catch(() => caches.match('/'))
+        );
+        return;
     }
     
     // For everything else (HTML, images), serve from cache if available


### PR DESCRIPTION
## Summary
- disable caching on live API responses and client fetches
- refresh dashboard polling when the tab regains focus or returns from bfcache
- bump the service worker cache version and clear old caches so updated assets load

## Testing
- validated no editor errors in app.py, static/dashboard.js, and static/sw.js