### PR TITLE
fix(pwa): harden cache refresh and service worker update flow

### DIFF
--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -385,18 +385,22 @@ function renderClientsTable() {
         // 9. Register PWA Service Worker
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
+                // Capture whether a controller already exists before registering,
+                // so controllerchange only triggers a reload when upgrading (not on first install).
+                const hadController = !!navigator.serviceWorker.controller;
+
+                let isRefreshing = false;
+                navigator.serviceWorker.addEventListener('controllerchange', () => {
+                    if (isRefreshing || !hadController) {
+                        return;
+                    }
+                    isRefreshing = true;
+                    window.location.reload();
+                });
+
                 navigator.serviceWorker.register('/sw.js')
                     .then(reg => {
                         console.log('PWA Service Worker Registered!', reg.scope);
-
-                        let isRefreshing = false;
-                        navigator.serviceWorker.addEventListener('controllerchange', () => {
-                            if (isRefreshing) {
-                                return;
-                            }
-                            isRefreshing = true;
-                            window.location.reload();
-                        });
 
                         if (reg.waiting) {
                             reg.waiting.postMessage({ type: 'SKIP_WAITING' });

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -386,7 +386,35 @@ function renderClientsTable() {
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
                 navigator.serviceWorker.register('/sw.js')
-                    .then(reg => console.log('PWA Service Worker Registered!', reg.scope))
+                    .then(reg => {
+                        console.log('PWA Service Worker Registered!', reg.scope);
+
+                        let isRefreshing = false;
+                        navigator.serviceWorker.addEventListener('controllerchange', () => {
+                            if (isRefreshing) {
+                                return;
+                            }
+                            isRefreshing = true;
+                            window.location.reload();
+                        });
+
+                        if (reg.waiting) {
+                            reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+                        }
+
+                        reg.addEventListener('updatefound', () => {
+                            const newWorker = reg.installing;
+                            if (!newWorker) {
+                                return;
+                            }
+
+                            newWorker.addEventListener('statechange', () => {
+                                if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                                    newWorker.postMessage({ type: 'SKIP_WAITING' });
+                                }
+                            });
+                        });
+                    })
                     .catch(err => console.error('PWA Registration Failed!', err));
             });
         }

--- a/static/sw.js
+++ b/static/sw.js
@@ -64,17 +64,18 @@ self.addEventListener('fetch', event => {
     if (url.pathname.startsWith('/static/') || url.pathname === '/manifest.json') {
         event.respondWith(
             caches.match(event.request).then(cached => {
-                const networkFetch = fetch(event.request)
+                const networkFetch = fetch(event.request);
+                const cacheUpdate = networkFetch
                     .then(response => {
                         if (response && response.ok) {
                             const responseCopy = response.clone();
-                            caches.open(CACHE_NAME).then(cache => cache.put(event.request, responseCopy));
+                            return caches.open(CACHE_NAME).then(cache => cache.put(event.request, responseCopy));
                         }
-                        return response;
-                    })
-                    .catch(() => cached);
+                    });
 
-                return cached || networkFetch;
+                event.waitUntil(cacheUpdate.catch(() => {}));
+
+                return cached || networkFetch.catch(() => cached);
             })
         );
         return;

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ntp-dash-v2';
+const CACHE_NAME = 'ntp-dash-v3';
 const ASSETS_TO_CACHE =[
     '/',
     '/static/tailwindcss.js',
@@ -27,11 +27,29 @@ self.addEventListener('activate', event => {
     self.clients.claim();
 });
 
+self.addEventListener('message', event => {
+    if (event.data && event.data.type === 'SKIP_WAITING') {
+        self.skipWaiting();
+    }
+});
+
 // Fetch event: Serve cached files, but ALWAYS fetch fresh data from the API
 self.addEventListener('fetch', event => {
+    if (event.request.method !== 'GET') {
+        return;
+    }
+
+    const url = new URL(event.request.url);
+
+    // Only manage same-origin requests.
+    if (url.origin !== self.location.origin) {
+        return;
+    }
+
     // We NEVER want to cache the live time/GPS data APIs
-    if (event.request.url.includes('/api/')) {
-        return; 
+    if (url.pathname.startsWith('/api/')) {
+        event.respondWith(fetch(event.request));
+        return;
     }
 
     // For navigations (HTML), prefer network so UI/JS updates arrive quickly.
@@ -41,11 +59,31 @@ self.addEventListener('fetch', event => {
         );
         return;
     }
+
+    // Stale-while-revalidate for static assets keeps app responsive while refreshing cache in background.
+    if (url.pathname.startsWith('/static/') || url.pathname === '/manifest.json') {
+        event.respondWith(
+            caches.match(event.request).then(cached => {
+                const networkFetch = fetch(event.request)
+                    .then(response => {
+                        if (response && response.ok) {
+                            const responseCopy = response.clone();
+                            caches.open(CACHE_NAME).then(cache => cache.put(event.request, responseCopy));
+                        }
+                        return response;
+                    })
+                    .catch(() => cached);
+
+                return cached || networkFetch;
+            })
+        );
+        return;
+    }
     
-    // For everything else (HTML, images), serve from cache if available
+    // Fallback strategy for any other same-origin GET request.
     event.respondWith(
-        caches.match(event.request).then(response => {
-            return response || fetch(event.request);
+        fetch(event.request).catch(() => {
+            return caches.match(event.request);
         })
     );
 });


### PR DESCRIPTION
## Why
PWA users could continue running stale assets longer than browser-tab users, causing web GUI/PWA behavior drift after releases.

## Changes
- Bumped SW cache name to force release refresh
- Added SKIP_WAITING message handling in service worker
- Added explicit same-origin and GET-only request handling
- Kept API traffic network-only
- Implemented stale-while-revalidate for static assets
- Added client-side SW update handoff:
  - trigger waiting worker activation
  - handle updatefound/install flow
  - reload once on controllerchange

## Validation
- Verified updated files load without syntax/errors
- Confirmed cache/update lifecycle hooks exist in SW and dashboard registration code.