### PR TITLE
fix(security): apply v0.1.2 fixable Grype remediations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.15.0a6-alpine
+FROM python:3.13-alpine3.21
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 # 1. Install the default local runtime tools
 ARG INSTALL_GPSD_CLIENTS=false
 RUN set -eux; \
-	apk add --no-cache chrony zlib=1.3.2-r0; \
+	apk add --no-cache chrony "zlib>=1.3.2-r0"; \
 	if [ "$INSTALL_GPSD_CLIENTS" = "true" ]; then \
 		apk add --no-cache gpsd-clients; \
 	fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /app/static && wget -q https://cdn.tailwindcss.com/ -O /app/static/
 
 # 3. Install Python requirements
 COPY requirements.txt .
-RUN pip install --no-cache-dir --upgrade pip==26.0 \
+RUN pip install --no-cache-dir --upgrade "pip>=26,<27" \
 	&& pip install --no-cache-dir -r requirements.txt
 
 # 4. Copy the app files (.dockerignore will block the junk automatically)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.14-alpine
+FROM python:3.15.0a6-alpine
 
 WORKDIR /app
 
 # 1. Install the default local runtime tools
 ARG INSTALL_GPSD_CLIENTS=false
 RUN set -eux; \
-	apk add --no-cache chrony; \
+	apk add --no-cache chrony zlib=1.3.2-r0; \
 	if [ "$INSTALL_GPSD_CLIENTS" = "true" ]; then \
 		apk add --no-cache gpsd-clients; \
 	fi
@@ -15,7 +15,8 @@ RUN mkdir -p /app/static && wget -q https://cdn.tailwindcss.com/ -O /app/static/
 
 # 3. Install Python requirements
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --upgrade pip==26.0 \
+	&& pip install --no-cache-dir -r requirements.txt
 
 # 4. Copy the app files (.dockerignore will block the junk automatically)
 COPY . .


### PR DESCRIPTION
## Summary
- update Python base image to 3.15.0a6-alpine
- pin zlib to 1.3.2-r0
- upgrade pip to 26.0 during image build

## Scan source
Based on grype-scans/v0.1.2 artifacts and fix versions reported there.