### PR TITLE
fix(docker): remove zlib pin regression in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 # 1. Install the default local runtime tools
 ARG INSTALL_GPSD_CLIENTS=false
 RUN set -eux; \
-	apk add --no-cache chrony "zlib>=1.3.2-r0"; \
+	apk add --no-cache chrony; \
 	if [ "$INSTALL_GPSD_CLIENTS" = "true" ]; then \
 		apk add --no-cache gpsd-clients; \
 	fi


### PR DESCRIPTION
## Summary
- remove strict zlib version pin from Dockerfile package install
- keep chrony install unchanged

## Why
Builds on Alpine 3.21/aarch64 failed because zlib>=1.3.2-r0 was unavailable in the target repository, causing apk resolution errors.

## Validation
- confirmed Dockerfile now uses: apk add --no-cache chrony
- regression diff is limited to a single line