### PR TITLE
Security remediation: v0.1.3 Grype findings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM python:3.13-alpine3.21
+FROM python:3.13.12-alpine3.21
 
 WORKDIR /app
 
 # 1. Install the default local runtime tools
 ARG INSTALL_GPSD_CLIENTS=false
 RUN set -eux; \
+	apk upgrade --no-cache; \
 	apk add --no-cache chrony; \
 	if [ "$INSTALL_GPSD_CLIENTS" = "true" ]; then \
 		apk add --no-cache gpsd-clients; \


### PR DESCRIPTION
- Update Python base image to 3.13.12 on Alpine 3.21
- Run apk upgrade during image build
- Target fixable OpenSSL/BusyBox/Python runtime findings from v0.1.3 scan