### PR TITLE
ci: fix grype-remediation-suggestions trigger, run ID resolution, underfixed false-positives, and least-privilege

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,45 +1,37 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  # 1. Python dependencies
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "pre-update-release"   # <--- CHANGE THIS TO YOUR ACTUAL BRANCH NAME
+    target-branch: "pre-update-release"
     schedule:
       interval: "weekly"
-      day: "wednesday"          # Options: monday, tuesday, etc.
-      time: "06:00"          # 24-hour format (HH:MM)
-      timezone: "America/New_York" # Your local timezone
+      day: "wednesday"
+      time: "09:30"
+      timezone: "America/New_York"
     labels:
       - "dependencies"
       - "python"
 
-  # 2. Docker base images
   - package-ecosystem: "docker"
     directory: "/"
-    target-branch: "pre-update-release"   # <--- CHANGE THIS TO YOUR ACTUAL BRANCH NAME
+    target-branch: "pre-update-release"
     schedule:
       interval: "weekly"
-      day: "wednesday"          # Options: monday, tuesday, etc.
-      time: "06:00"          # 24-hour format (HH:MM)
-      timezone: "America/New_York" # Your local timezone
+      day: "wednesday"
+      time: "09:30"
+      timezone: "America/New_York"
     labels:
       - "dependencies"
       - "docker"
 
-  # 3. GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "pre-update-release"   # <--- CHANGE THIS TO YOUR ACTUAL BRANCH NAME
+    target-branch: "pre-update-release"
     schedule:
       interval: "weekly"
-      day: "wednesday"          # Options: monday, tuesday, etc.
-      time: "06:00"          # 24-hour format (HH:MM)
-      timezone: "America/New_York" # Your local timezone
+      day: "wednesday"
+      time: "09:30"
+      timezone: "America/New_York"
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/dependabot-grype-guard.yml
+++ b/.github/workflows/dependabot-grype-guard.yml
@@ -1,0 +1,198 @@
+name: Dependabot Grype Guard
+
+"on":
+  pull_request:
+    branches:
+      - pre-update-release
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  grype-guard:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_PR: ntp-dashboard:dependabot-pr
+      IMAGE_BASE: ntp-dashboard:dependabot-base
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          path: pr
+
+      - name: Checkout base commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Discover latest Grype release
+        id: grype-release
+        run: |
+          set -euo pipefail
+          tag="$(python -c 'import json,urllib.request; req=urllib.request.Request("https://api.github.com/repos/anchore/grype/releases/latest", headers={"Accept":"application/vnd.github+json","User-Agent":"ntp-dashboard-dependabot-grype-guard"}); data=json.load(urllib.request.urlopen(req, timeout=30)); print(data["tag_name"])')"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Pull latest Grype image
+        run: |
+          set -euo pipefail
+          docker pull "anchore/grype:${{ steps.grype-release.outputs.tag }}"
+
+      - name: Build PR and base images
+        run: |
+          set -euo pipefail
+          docker build --build-arg INSTALL_GPSD_CLIENTS=false -t "$IMAGE_PR" ./pr
+          docker build --build-arg INSTALL_GPSD_CLIENTS=false -t "$IMAGE_BASE" ./base
+
+      - name: Update Grype DB
+        run: |
+          set -euo pipefail
+          mkdir -p grype-db-cache security-reports
+
+          docker run --rm \
+            -e GRYPE_DB_CACHE_DIR=/grype-db \
+            -e GRYPE_DB_VALIDATE_AGE=false \
+            -v "$PWD/grype-db-cache":/grype-db \
+            "anchore/grype:${{ steps.grype-release.outputs.tag }}" db update
+
+      - name: Scan base and PR images
+        run: |
+          set -euo pipefail
+
+          docker run --rm \
+            -e GRYPE_DB_CACHE_DIR=/grype-db \
+            -e GRYPE_DB_VALIDATE_AGE=false \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$PWD/grype-db-cache":/grype-db \
+            "anchore/grype:${{ steps.grype-release.outputs.tag }}" \
+            "$IMAGE_BASE" \
+            -o json > security-reports/grype-base.json
+
+          docker run --rm \
+            -e GRYPE_DB_CACHE_DIR=/grype-db \
+            -e GRYPE_DB_VALIDATE_AGE=false \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$PWD/grype-db-cache":/grype-db \
+            "anchore/grype:${{ steps.grype-release.outputs.tag }}" \
+            "$IMAGE_PR" \
+            -o json > security-reports/grype-pr.json
+
+      - name: Compare scan results and enforce regression gate
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          from collections import Counter
+          from pathlib import Path
+
+          base = json.loads(Path("security-reports/grype-base.json").read_text(encoding="utf-8"))
+          pr = json.loads(Path("security-reports/grype-pr.json").read_text(encoding="utf-8"))
+
+          levels = ["Critical", "High", "Medium", "Low", "Negligible", "Unknown"]
+
+          def counts(doc):
+              c = Counter()
+              for m in doc.get("matches", []):
+                  sev = m.get("vulnerability", {}).get("severity", "Unknown").title()
+                  c[sev] += 1
+              return c
+
+          def fixed_recommendations(doc):
+              recs = {}
+              for m in doc.get("matches", []):
+                  vuln = m.get("vulnerability", {})
+                  fix = vuln.get("fix", {}) or {}
+                  if fix.get("state") != "fixed":
+                      continue
+                  artifact = m.get("artifact", {})
+                  pkg = artifact.get("name", "unknown")
+                  versions = tuple(fix.get("versions", []))
+                  if not versions:
+                      continue
+                  bucket = recs.setdefault(pkg, set())
+                  for v in versions:
+                      bucket.add(v)
+              return {k: sorted(v) for k, v in sorted(recs.items())}
+
+          def vulnerable_pkg_versions(doc):
+              pkgs = {}
+              for m in doc.get("matches", []):
+                  vuln = m.get("vulnerability", {})
+                  sev = vuln.get("severity", "Unknown").title()
+                  artifact = m.get("artifact", {})
+                  pkg = artifact.get("name", "unknown")
+                  version = artifact.get("version", "unknown")
+                  bucket = pkgs.setdefault(pkg, {"versions": set(), "severities": set()})
+                  bucket["versions"].add(version)
+                  bucket["severities"].add(sev)
+              return pkgs
+
+          base_counts = counts(base)
+          pr_counts = counts(pr)
+          base_pkgs = vulnerable_pkg_versions(base)
+          pr_pkgs = vulnerable_pkg_versions(pr)
+
+          summary_lines = [
+              "## Dependabot Grype Guard",
+              "",
+              "| Severity | Base | PR | Delta |",
+              "|---|---:|---:|---:|",
+          ]
+          for lvl in levels:
+              b = base_counts.get(lvl, 0)
+              p = pr_counts.get(lvl, 0)
+              summary_lines.append(f"| {lvl} | {b} | {p} | {p - b:+d} |")
+
+          recs = fixed_recommendations(pr)
+          if recs:
+              summary_lines.extend(["", "### Fixable package recommendations from PR image"])
+              for pkg, versions in recs.items():
+                  summary_lines.append(f"- {pkg}: {', '.join(versions)}")
+
+          changed_vulnerable_pkgs = []
+          for pkg in sorted(set(base_pkgs) | set(pr_pkgs)):
+              before = sorted(base_pkgs.get(pkg, {}).get("versions", set()))
+              after = sorted(pr_pkgs.get(pkg, {}).get("versions", set()))
+              if before != after:
+                  changed_vulnerable_pkgs.append(pkg)
+
+          underfixed_updates = []
+          for pkg in changed_vulnerable_pkgs:
+              if pkg not in recs:
+                  continue
+              severities = pr_pkgs.get(pkg, {}).get("severities", set())
+              if "High" in severities or "Critical" in severities:
+                  underfixed_updates.append(pkg)
+
+          if changed_vulnerable_pkgs:
+              summary_lines.extend(["", "### Vulnerable packages changed by this PR"])
+              for pkg in changed_vulnerable_pkgs:
+                  before = ", ".join(sorted(base_pkgs.get(pkg, {}).get("versions", set()))) or "none"
+                  after = ", ".join(sorted(pr_pkgs.get(pkg, {}).get("versions", set()))) or "none"
+                  summary_lines.append(f"- {pkg}: {before} -> {after}")
+
+          summary = "\n".join(summary_lines) + "\n"
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as f:
+              f.write(summary)
+
+          critical_regression = pr_counts.get("Critical", 0) > base_counts.get("Critical", 0)
+          high_regression = pr_counts.get("High", 0) > base_counts.get("High", 0)
+
+          if underfixed_updates:
+              pkg_list = ", ".join(sorted(underfixed_updates))
+              raise SystemExit(f"Failing due to underfixed Dependabot updates for High/Critical vulnerable packages: {pkg_list}")
+
+          if critical_regression or high_regression:
+              raise SystemExit("Failing due to High/Critical vulnerability regression in Dependabot PR")
+          PY
+
+      - name: Upload guard artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: dependabot-grype-guard-reports
+          path: security-reports/

--- a/.github/workflows/dependabot-grype-guard.yml
+++ b/.github/workflows/dependabot-grype-guard.yml
@@ -7,7 +7,6 @@ name: Dependabot Grype Guard
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   grype-guard:
@@ -118,6 +117,27 @@ jobs:
                       bucket.add(v)
               return {k: sorted(v) for k, v in sorted(recs.items())}
 
+          def fixed_high_critical_recommendations(doc):
+              high_critical = {"High", "Critical"}
+              recs = {}
+              for m in doc.get("matches", []):
+                  vuln = m.get("vulnerability", {})
+                  sev = vuln.get("severity", "Unknown").title()
+                  if sev not in high_critical:
+                      continue
+                  fix = vuln.get("fix", {}) or {}
+                  if fix.get("state") != "fixed":
+                      continue
+                  artifact = m.get("artifact", {})
+                  pkg = artifact.get("name", "unknown")
+                  versions = tuple(fix.get("versions", []))
+                  if not versions:
+                      continue
+                  bucket = recs.setdefault(pkg, set())
+                  for v in versions:
+                      bucket.add(v)
+              return {k: sorted(v) for k, v in sorted(recs.items())}
+
           def vulnerable_pkg_versions(doc):
               pkgs = {}
               for m in doc.get("matches", []):
@@ -135,6 +155,9 @@ jobs:
           pr_counts = counts(pr)
           base_pkgs = vulnerable_pkg_versions(base)
           pr_pkgs = vulnerable_pkg_versions(pr)
+
+          recs = fixed_recommendations(pr)
+          high_critical_recs = fixed_high_critical_recommendations(pr)
 
           summary_lines = [
               "## Dependabot Grype Guard",
@@ -160,13 +183,10 @@ jobs:
               if before != after:
                   changed_vulnerable_pkgs.append(pkg)
 
-          underfixed_updates = []
-          for pkg in changed_vulnerable_pkgs:
-              if pkg not in recs:
-                  continue
-              severities = pr_pkgs.get(pkg, {}).get("severities", set())
-              if "High" in severities or "Critical" in severities:
-                  underfixed_updates.append(pkg)
+          underfixed_updates = [
+              pkg for pkg in changed_vulnerable_pkgs
+              if pkg in high_critical_recs
+          ]
 
           if changed_vulnerable_pkgs:
               summary_lines.extend(["", "### Vulnerable packages changed by this PR"])

--- a/.github/workflows/grype-remediation-suggestions.yml
+++ b/.github/workflows/grype-remediation-suggestions.yml
@@ -37,6 +37,7 @@ jobs:
             echo "id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
           else
             python - <<'PY'
+            import datetime
             import json
             import os
             import urllib.parse
@@ -68,17 +69,32 @@ jobs:
             if workflow_id is None:
                 raise SystemExit(f"Workflow not found: {workflow_name}")
 
-            params = urllib.parse.urlencode({
-                "status": "success",
-                "branch": branch,
-                "per_page": 1,
-            })
-            runs_url = f"https://api.github.com/repos/{repo}/actions/workflows/{workflow_id}/runs?{params}"
-            runs_req = urllib.request.Request(runs_url, headers=headers)
-            with urllib.request.urlopen(runs_req, timeout=30) as resp:
-                runs = json.loads(resp.read().decode("utf-8"))
+            def fetch_runs(extra_params=None):
+                params = {
+                    "status": "success",
+                    "branch": branch,
+                    "per_page": 1,
+                }
+                if extra_params:
+                    params.update(extra_params)
+                runs_url = (
+                    f"https://api.github.com/repos/{repo}/actions/workflows/"
+                    f"{workflow_id}/runs?{urllib.parse.urlencode(params)}"
+                )
+                runs_req = urllib.request.Request(runs_url, headers=headers)
+                with urllib.request.urlopen(runs_req, timeout=30) as resp:
+                    return json.loads(resp.read().decode("utf-8")).get("workflow_runs", [])
 
-            workflow_runs = runs.get("workflow_runs", [])
+            # Prefer a scan that completed within the last 7 days (same-week window).
+            now = datetime.datetime.now(datetime.timezone.utc)
+            week_ago = now - datetime.timedelta(days=7)
+            created_filter = f">={week_ago.strftime('%Y-%m-%dT%H:%M:%SZ')}"
+
+            workflow_runs = fetch_runs({"created": created_filter})
+            if not workflow_runs:
+                # Fall back to the most recent successful run if none found this week.
+                workflow_runs = fetch_runs()
+
             if not workflow_runs:
                 raise SystemExit(
                     f"No successful runs found for workflow '{workflow_name}' on branch '{branch}'"

--- a/.github/workflows/grype-remediation-suggestions.yml
+++ b/.github/workflows/grype-remediation-suggestions.yml
@@ -1,0 +1,226 @@
+name: Grype Remediation Suggestions
+
+on:
+  workflow_run:
+    workflows:
+      - Weekly Grype Security Scan
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Optional workflow run ID to process
+        required: false
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  suggest-remediation:
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'pre-update-release')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve source workflow run ID
+        id: run
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.run_id }}" ]; then
+            echo "id=${{ inputs.run_id }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download weekly security artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ steps.run.outputs.id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+          import zipfile
+          from pathlib import Path
+
+          token = os.environ["GH_TOKEN"]
+          repo = os.environ["REPO"]
+          run_id = os.environ["RUN_ID"]
+
+          api_url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/artifacts"
+          req = urllib.request.Request(api_url, headers={
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "User-Agent": "ntp-dashboard-grype-remediation-suggestions",
+          })
+
+          with urllib.request.urlopen(req, timeout=30) as resp:
+              artifacts = json.loads(resp.read().decode("utf-8"))
+
+          selected = None
+          for art in artifacts.get("artifacts", []):
+              if art.get("name") == "weekly-security-reports" and not art.get("expired", False):
+                  selected = art
+                  break
+
+          if not selected:
+              raise SystemExit("No weekly-security-reports artifact found for the selected run")
+
+          dl_req = urllib.request.Request(selected["archive_download_url"], headers={
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "User-Agent": "ntp-dashboard-grype-remediation-suggestions",
+          })
+
+          zip_path = Path("artifact.zip")
+          with urllib.request.urlopen(dl_req, timeout=60) as resp:
+              zip_path.write_bytes(resp.read())
+
+          out_dir = Path("security-reports")
+          out_dir.mkdir(parents=True, exist_ok=True)
+
+          with zipfile.ZipFile(zip_path, "r") as zf:
+              zf.extractall(out_dir)
+          PY
+
+      - name: Build remediation recommendation report
+        id: report
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          from collections import Counter
+          from pathlib import Path
+
+          report_md = Path("security-reports/weekly-security-report.md")
+          scan_json = Path("security-reports/grype-image-local.json")
+
+          if not report_md.exists() or not scan_json.exists():
+              raise SystemExit("Expected weekly-security-report.md and grype-image-local.json in artifact")
+
+          data = json.loads(scan_json.read_text(encoding="utf-8"))
+          matches = data.get("matches", [])
+
+          severity_counts = Counter()
+          recommendations = {}
+
+          for match in matches:
+              vuln = match.get("vulnerability", {})
+              fix = vuln.get("fix", {}) or {}
+              artifact = match.get("artifact", {})
+
+              sev = vuln.get("severity", "Unknown").title()
+              severity_counts[sev] += 1
+
+              if fix.get("state") != "fixed":
+                  continue
+
+              pkg = artifact.get("name", "unknown")
+              current = artifact.get("version", "unknown")
+              fixes = fix.get("versions", [])
+              if not fixes:
+                  continue
+
+              bucket = recommendations.setdefault(pkg, {
+                  "current_versions": set(),
+                  "target_versions": set(),
+                  "severities": set(),
+              })
+              bucket["current_versions"].add(current)
+              bucket["target_versions"].update(fixes)
+              bucket["severities"].add(sev)
+
+          ordered = sorted(
+              recommendations.items(),
+              key=lambda item: (
+                  0 if "Critical" in item[1]["severities"] else 1 if "High" in item[1]["severities"] else 2,
+                  item[0],
+              ),
+          )
+
+          lines = [
+              "# Grype Remediation Suggestions",
+              "",
+              "This issue is generated automatically from the latest successful weekly Grype scan artifact.",
+              "",
+              "## Local Image Scan Snapshot",
+              "",
+              f"- Critical: {severity_counts.get('Critical', 0)}",
+              f"- High: {severity_counts.get('High', 0)}",
+              f"- Medium: {severity_counts.get('Medium', 0)}",
+              f"- Low: {severity_counts.get('Low', 0)}",
+              "",
+              "## Fixable Recommendations",
+              "",
+          ]
+
+          if not ordered:
+              lines.append("No fixable package updates were reported by Grype for the local image scan.")
+              has_recommendations = "false"
+          else:
+              lines.append("| Package | Current | Recommended target(s) | Highest severity |")
+              lines.append("|---|---|---|---|")
+              for pkg, rec in ordered:
+                  highest = "Critical" if "Critical" in rec["severities"] else "High" if "High" in rec["severities"] else "Medium" if "Medium" in rec["severities"] else "Low"
+                  current = ", ".join(sorted(rec["current_versions"]))
+                  target = ", ".join(sorted(rec["target_versions"]))
+                  lines.append(f"| {pkg} | {current} | {target} | {highest} |")
+              has_recommendations = "true"
+
+          lines.extend([
+              "",
+              "## Notes",
+              "",
+              "- Dependabot PRs should be reviewed against this recommendation set.",
+              "- The Dependabot Grype Guard workflow enforces no High/Critical regression on merge.",
+          ])
+
+          body = "\n".join(lines) + "\n"
+          Path("remediation-issue.md").write_text(body, encoding="utf-8")
+          Path("report-flags.txt").write_text(has_recommendations, encoding="utf-8")
+          PY
+
+          echo "has_recommendations=$(cat report-flags.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update remediation tracking issue
+        if: steps.report.outputs.has_recommendations == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = 'Grype remediation suggestions';
+            const body = fs.readFileSync('remediation-issue.md', 'utf8');
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const existing = issues.find(i => i.title.toLowerCase() === title.toLowerCase());
+
+            if (existing) {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body,
+              });
+              core.notice(`Updated issue #${existing.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+              });
+              core.notice(`Created issue #${created.data.number}`);
+            }

--- a/.github/workflows/grype-remediation-suggestions.yml
+++ b/.github/workflows/grype-remediation-suggestions.yml
@@ -29,12 +29,68 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.run_id }}" ]; then
             echo "id=${{ inputs.run_id }}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" = "workflow_run" ]; then
             echo "id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
+          else
+            python - <<'PY'
+            import json
+            import os
+            import urllib.parse
+            import urllib.request
+
+            token = os.environ["GH_TOKEN"]
+            repo = os.environ["REPO"]
+            workflow_name = "Weekly Grype Security Scan"
+            branch = "pre-update-release"
+            output_path = os.environ["GITHUB_OUTPUT"]
+
+            headers = {
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "User-Agent": "ntp-dashboard-grype-remediation-suggestions",
+            }
+
+            workflows_url = f"https://api.github.com/repos/{repo}/actions/workflows"
+            workflows_req = urllib.request.Request(workflows_url, headers=headers)
+            with urllib.request.urlopen(workflows_req, timeout=30) as resp:
+                workflows = json.loads(resp.read().decode("utf-8"))
+
+            workflow_id = None
+            for workflow in workflows.get("workflows", []):
+                if workflow.get("name") == workflow_name:
+                    workflow_id = workflow["id"]
+                    break
+
+            if workflow_id is None:
+                raise SystemExit(f"Workflow not found: {workflow_name}")
+
+            params = urllib.parse.urlencode({
+                "status": "success",
+                "branch": branch,
+                "per_page": 1,
+            })
+            runs_url = f"https://api.github.com/repos/{repo}/actions/workflows/{workflow_id}/runs?{params}"
+            runs_req = urllib.request.Request(runs_url, headers=headers)
+            with urllib.request.urlopen(runs_req, timeout=30) as resp:
+                runs = json.loads(resp.read().decode("utf-8"))
+
+            workflow_runs = runs.get("workflow_runs", [])
+            if not workflow_runs:
+                raise SystemExit(
+                    f"No successful runs found for workflow '{workflow_name}' on branch '{branch}'"
+                )
+
+            run_id = workflow_runs[0]["id"]
+            with open(output_path, "a", encoding="utf-8") as fh:
+                fh.write(f"id={run_id}\n")
+            PY
           else
             python - <<'PY'
             import datetime

--- a/.github/workflows/grype-remediation-suggestions.yml
+++ b/.github/workflows/grype-remediation-suggestions.yml
@@ -20,18 +20,74 @@ permissions:
 
 jobs:
   suggest-remediation:
-    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'pre-update-release')
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     steps:
       - name: Resolve source workflow run ID
         id: run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.run_id }}" ]; then
             echo "id=${{ inputs.run_id }}" >> "$GITHUB_OUTPUT"
-          else
+          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
             echo "id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
+          else
+            python - <<'PY'
+            import json
+            import os
+            import urllib.parse
+            import urllib.request
+
+            token = os.environ["GH_TOKEN"]
+            repo = os.environ["REPO"]
+            workflow_name = "Weekly Grype Security Scan"
+            branch = "pre-update-release"
+            output_path = os.environ["GITHUB_OUTPUT"]
+
+            headers = {
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "User-Agent": "ntp-dashboard-grype-remediation-suggestions",
+            }
+
+            workflows_url = f"https://api.github.com/repos/{repo}/actions/workflows"
+            workflows_req = urllib.request.Request(workflows_url, headers=headers)
+            with urllib.request.urlopen(workflows_req, timeout=30) as resp:
+                workflows = json.loads(resp.read().decode("utf-8"))
+
+            workflow_id = None
+            for workflow in workflows.get("workflows", []):
+                if workflow.get("name") == workflow_name:
+                    workflow_id = workflow["id"]
+                    break
+
+            if workflow_id is None:
+                raise SystemExit(f"Workflow not found: {workflow_name}")
+
+            params = urllib.parse.urlencode({
+                "status": "success",
+                "branch": branch,
+                "per_page": 1,
+            })
+            runs_url = f"https://api.github.com/repos/{repo}/actions/workflows/{workflow_id}/runs?{params}"
+            runs_req = urllib.request.Request(runs_url, headers=headers)
+            with urllib.request.urlopen(runs_req, timeout=30) as resp:
+                runs = json.loads(resp.read().decode("utf-8"))
+
+            workflow_runs = runs.get("workflow_runs", [])
+            if not workflow_runs:
+                raise SystemExit(
+                    f"No successful runs found for workflow '{workflow_name}' on branch '{branch}'"
+                )
+
+            run_id = workflow_runs[0]["id"]
+            with open(output_path, "a", encoding="utf-8") as fh:
+                fh.write(f"id={run_id}\n")
+            PY
           fi
 
       - name: Download weekly security artifact
@@ -205,7 +261,7 @@ jobs:
               per_page: 100,
             });
 
-            const existing = issues.find(i => i.title.toLowerCase() === title.toLowerCase());
+            const existing = issues.find(i => i.title.toLowerCase() === title.toLowerCase() && !i.pull_request);
 
             if (existing) {
               await github.rest.issues.update({


### PR DESCRIPTION
Five correctness and security issues across the Grype automation workflows, including a condition that silently prevented the remediation-suggestions workflow from ever running automatically.

## `grype-remediation-suggestions.yml`

- **Drop `head_branch` guard** — `workflow_run.head_branch` reflects the branch owning the workflow file (`main`), not the branch checked out internally. The `== 'pre-update-release'` condition always evaluated false for scheduled runs.
- **Fix `workflow_dispatch` run ID fallback** — when `run_id` is omitted, `github.event.workflow_run.id` is empty on `workflow_dispatch` events. Now resolves via API: prefers the most recent successful `Weekly Grype Security Scan` run on `pre-update-release` within the last 7 days, falls back to the absolute latest if none found.
- **Filter PRs from issue search** — `issues.listForRepo` returns both issues and PRs; added `&& !i.pull_request` to prevent accidentally updating a PR body instead of the tracking issue.

## `dependabot-grype-guard.yml`

- **Drop `pull-requests: write`** — the workflow only writes to `GITHUB_STEP_SUMMARY` and uploads artifacts; issue/PR creation from scan results is handled by `grype-remediation-suggestions.yml`. Only `contents: read` is required.
- **Scope `underfixed_updates` to High/Critical fixable vulns** — the previous logic false-positived when a package had an unrelated unfixable High vuln alongside a Medium fixable vuln. Added `fixed_high_critical_recommendations()` that filters to High/Critical severity before checking fix state; a package is only flagged underfixed if it was changed *and* still carries a fixable High/Critical finding in the PR image.

```python
# Before: any fixable vuln on the package triggered the check
underfixed_updates = [pkg for pkg in changed if pkg in recs and ("High" in severities or "Critical" in severities)]

# After: only packages with High/Critical fixable vulns are considered
high_critical_recs = fixed_high_critical_recommendations(pr)  # scoped to sev ∈ {High, Critical}
underfixed_updates = [pkg for pkg in changed if pkg in high_critical_recs]
```