### PR TITLE
fix: remove hard-coded branch filter from workflow_dispatch fallback in grype-remediation-suggestions

### DIFF
--- a/.github/workflows/grype-remediation-suggestions.yml
+++ b/.github/workflows/grype-remediation-suggestions.yml
@@ -46,7 +46,6 @@ jobs:
             token = os.environ["GH_TOKEN"]
             repo = os.environ["REPO"]
             workflow_name = "Weekly Grype Security Scan"
-            branch = "pre-update-release"
             output_path = os.environ["GITHUB_OUTPUT"]
 
             headers = {
@@ -72,7 +71,6 @@ jobs:
             def fetch_runs(extra_params=None):
                 params = {
                     "status": "success",
-                    "branch": branch,
                     "per_page": 1,
                 }
                 if extra_params:
@@ -97,7 +95,7 @@ jobs:
 
             if not workflow_runs:
                 raise SystemExit(
-                    f"No successful runs found for workflow '{workflow_name}' on branch '{branch}'"
+                    f"No successful runs found for workflow '{workflow_name}'"
                 )
 
             run_id = workflow_runs[0]["id"]

--- a/.github/workflows/grype-remediation-suggestions.yml
+++ b/.github/workflows/grype-remediation-suggestions.yml
@@ -1,0 +1,298 @@
+name: Grype Remediation Suggestions
+
+on:
+  workflow_run:
+    workflows:
+      - Weekly Grype Security Scan
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Optional workflow run ID to process
+        required: false
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  suggest-remediation:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve source workflow run ID
+        id: run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.run_id }}" ]; then
+            echo "id=${{ inputs.run_id }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
+          else
+            python - <<'PY'
+            import datetime
+            import json
+            import os
+            import urllib.parse
+            import urllib.request
+
+            token = os.environ["GH_TOKEN"]
+            repo = os.environ["REPO"]
+            workflow_name = "Weekly Grype Security Scan"
+            branch = "pre-update-release"
+            output_path = os.environ["GITHUB_OUTPUT"]
+
+            headers = {
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "User-Agent": "ntp-dashboard-grype-remediation-suggestions",
+            }
+
+            workflows_url = f"https://api.github.com/repos/{repo}/actions/workflows"
+            workflows_req = urllib.request.Request(workflows_url, headers=headers)
+            with urllib.request.urlopen(workflows_req, timeout=30) as resp:
+                workflows = json.loads(resp.read().decode("utf-8"))
+
+            workflow_id = None
+            for workflow in workflows.get("workflows", []):
+                if workflow.get("name") == workflow_name:
+                    workflow_id = workflow["id"]
+                    break
+
+            if workflow_id is None:
+                raise SystemExit(f"Workflow not found: {workflow_name}")
+
+            def fetch_runs(extra_params=None):
+                params = {
+                    "status": "success",
+                    "branch": branch,
+                    "per_page": 1,
+                }
+                if extra_params:
+                    params.update(extra_params)
+                runs_url = (
+                    f"https://api.github.com/repos/{repo}/actions/workflows/"
+                    f"{workflow_id}/runs?{urllib.parse.urlencode(params)}"
+                )
+                runs_req = urllib.request.Request(runs_url, headers=headers)
+                with urllib.request.urlopen(runs_req, timeout=30) as resp:
+                    return json.loads(resp.read().decode("utf-8")).get("workflow_runs", [])
+
+            # Prefer a scan that completed within the last 7 days (same-week window).
+            now = datetime.datetime.now(datetime.timezone.utc)
+            week_ago = now - datetime.timedelta(days=7)
+            created_filter = f">={week_ago.strftime('%Y-%m-%dT%H:%M:%SZ')}"
+
+            workflow_runs = fetch_runs({"created": created_filter})
+            if not workflow_runs:
+                # Fall back to the most recent successful run if none found this week.
+                workflow_runs = fetch_runs()
+
+            if not workflow_runs:
+                raise SystemExit(
+                    f"No successful runs found for workflow '{workflow_name}' on branch '{branch}'"
+                )
+
+            run_id = workflow_runs[0]["id"]
+            with open(output_path, "a", encoding="utf-8") as fh:
+                fh.write(f"id={run_id}\n")
+            PY
+          fi
+
+      - name: Download weekly security artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ steps.run.outputs.id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+          import zipfile
+          from pathlib import Path
+
+          token = os.environ["GH_TOKEN"]
+          repo = os.environ["REPO"]
+          run_id = os.environ["RUN_ID"]
+
+          api_url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/artifacts"
+          req = urllib.request.Request(api_url, headers={
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "User-Agent": "ntp-dashboard-grype-remediation-suggestions",
+          })
+
+          with urllib.request.urlopen(req, timeout=30) as resp:
+              artifacts = json.loads(resp.read().decode("utf-8"))
+
+          selected = None
+          for art in artifacts.get("artifacts", []):
+              if art.get("name") == "weekly-security-reports" and not art.get("expired", False):
+                  selected = art
+                  break
+
+          if not selected:
+              raise SystemExit("No weekly-security-reports artifact found for the selected run")
+
+          dl_req = urllib.request.Request(selected["archive_download_url"], headers={
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "User-Agent": "ntp-dashboard-grype-remediation-suggestions",
+          })
+
+          zip_path = Path("artifact.zip")
+          with urllib.request.urlopen(dl_req, timeout=60) as resp:
+              zip_path.write_bytes(resp.read())
+
+          out_dir = Path("security-reports")
+          out_dir.mkdir(parents=True, exist_ok=True)
+
+          with zipfile.ZipFile(zip_path, "r") as zf:
+              zf.extractall(out_dir)
+          PY
+
+      - name: Build remediation recommendation report
+        id: report
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          from collections import Counter
+          from pathlib import Path
+
+          report_md = Path("security-reports/weekly-security-report.md")
+          scan_json = Path("security-reports/grype-image-local.json")
+
+          if not report_md.exists() or not scan_json.exists():
+              raise SystemExit("Expected weekly-security-report.md and grype-image-local.json in artifact")
+
+          data = json.loads(scan_json.read_text(encoding="utf-8"))
+          matches = data.get("matches", [])
+
+          severity_counts = Counter()
+          recommendations = {}
+
+          for match in matches:
+              vuln = match.get("vulnerability", {})
+              fix = vuln.get("fix", {}) or {}
+              artifact = match.get("artifact", {})
+
+              sev = vuln.get("severity", "Unknown").title()
+              severity_counts[sev] += 1
+
+              if fix.get("state") != "fixed":
+                  continue
+
+              pkg = artifact.get("name", "unknown")
+              current = artifact.get("version", "unknown")
+              fixes = fix.get("versions", [])
+              if not fixes:
+                  continue
+
+              bucket = recommendations.setdefault(pkg, {
+                  "current_versions": set(),
+                  "target_versions": set(),
+                  "severities": set(),
+              })
+              bucket["current_versions"].add(current)
+              bucket["target_versions"].update(fixes)
+              bucket["severities"].add(sev)
+
+          ordered = sorted(
+              recommendations.items(),
+              key=lambda item: (
+                  0 if "Critical" in item[1]["severities"] else 1 if "High" in item[1]["severities"] else 2,
+                  item[0],
+              ),
+          )
+
+          lines = [
+              "# Grype Remediation Suggestions",
+              "",
+              "This issue is generated automatically from the latest successful weekly Grype scan artifact.",
+              "",
+              "## Local Image Scan Snapshot",
+              "",
+              f"- Critical: {severity_counts.get('Critical', 0)}",
+              f"- High: {severity_counts.get('High', 0)}",
+              f"- Medium: {severity_counts.get('Medium', 0)}",
+              f"- Low: {severity_counts.get('Low', 0)}",
+              "",
+              "## Fixable Recommendations",
+              "",
+          ]
+
+          if not ordered:
+              lines.append("No fixable package updates were reported by Grype for the local image scan.")
+              has_recommendations = "false"
+          else:
+              lines.append("| Package | Current | Recommended target(s) | Highest severity |")
+              lines.append("|---|---|---|---|")
+              for pkg, rec in ordered:
+                  highest = "Critical" if "Critical" in rec["severities"] else "High" if "High" in rec["severities"] else "Medium" if "Medium" in rec["severities"] else "Low"
+                  current = ", ".join(sorted(rec["current_versions"]))
+                  target = ", ".join(sorted(rec["target_versions"]))
+                  lines.append(f"| {pkg} | {current} | {target} | {highest} |")
+              has_recommendations = "true"
+
+          lines.extend([
+              "",
+              "## Notes",
+              "",
+              "- Dependabot PRs should be reviewed against this recommendation set.",
+              "- The Dependabot Grype Guard workflow enforces no High/Critical regression on merge.",
+          ])
+
+          body = "\n".join(lines) + "\n"
+          Path("remediation-issue.md").write_text(body, encoding="utf-8")
+          Path("report-flags.txt").write_text(has_recommendations, encoding="utf-8")
+          PY
+
+          echo "has_recommendations=$(cat report-flags.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update remediation tracking issue
+        if: steps.report.outputs.has_recommendations == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = 'Grype remediation suggestions';
+            const body = fs.readFileSync('remediation-issue.md', 'utf8');
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const existing = issues.find(i => i.title.toLowerCase() === title.toLowerCase() && !i.pull_request);
+
+            if (existing) {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body,
+              });
+              core.notice(`Updated issue #${existing.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+              });
+              core.notice(`Created issue #${created.data.number}`);
+            }


### PR DESCRIPTION
The `workflow_dispatch` fallback path queried the GitHub API with `branch = "pre-update-release"` to locate the most recent successful "Weekly Grype Security Scan" run. However, that workflow runs *from* `main` — it only checks out `pre-update-release` internally. The branch filter matched against the run's head branch, not the scanned target, so it always returned zero results and the fallback always failed.

## Changes

- **Removed** `branch = "pre-update-release"` variable and the corresponding `"branch": branch` param from `fetch_runs()` in the `workflow_dispatch` fallback Python block — the API call now returns the most recent successful run regardless of branch.
- **Simplified** the `SystemExit` error message that previously referenced the removed `branch` variable.

```diff
-branch = "pre-update-release"
 ...
 def fetch_runs(extra_params=None):
     params = {
         "status": "success",
-        "branch": branch,
         "per_page": 1,
     }
```