### PR TITLE
Security: apply Grype remediation recommendations (refs #101)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM python:3.14-alpine
+FROM python:3.14.3-alpine3.22
 
 WORKDIR /app
 
 # 1. Install the default local runtime tools
 ARG INSTALL_GPSD_CLIENTS=false
 RUN set -eux; \
+	apk upgrade --no-cache; \
 	apk add --no-cache chrony; \
 	if [ "$INSTALL_GPSD_CLIENTS" = "true" ]; then \
 		apk add --no-cache gpsd-clients; \


### PR DESCRIPTION
Implements baseline remediation from issue #101.

- Pin base image to python:3.14.3-alpine3.22
- Run apk upgrade during build to pick up patched Alpine packages

Refs #101