### PR TITLE
ci: close stale remediation issue when Grype finds zero fixable packages

### DIFF
--- a/.github/workflows/grype-remediation-suggestions.yml
+++ b/.github/workflows/grype-remediation-suggestions.yml
@@ -152,7 +152,6 @@ jobs:
           echo "has_recommendations=$(cat report-flags.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Create or update remediation tracking issue
-        if: steps.report.outputs.has_recommendations == 'true'
         uses: actions/github-script@v8
         with:
           script: |
@@ -161,6 +160,7 @@ jobs:
             const repo = context.repo.repo;
             const title = 'Grype remediation suggestions';
             const body = fs.readFileSync('remediation-issue.md', 'utf8');
+            const hasRecommendations = '${{ steps.report.outputs.has_recommendations }}' === 'true';
 
             const issues = await github.paginate(github.rest.issues.listForRepo, {
               owner,
@@ -171,20 +171,35 @@ jobs:
 
             const existing = issues.find(i => i.title.toLowerCase() === title.toLowerCase() && !i.pull_request);
 
-            if (existing) {
-              await github.rest.issues.update({
-                owner,
-                repo,
-                issue_number: existing.number,
-                body,
-              });
-              core.notice(`Updated issue #${existing.number}`);
+            if (hasRecommendations) {
+              if (existing) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: existing.number,
+                  body,
+                });
+                core.notice(`Updated issue #${existing.number}`);
+              } else {
+                const created = await github.rest.issues.create({
+                  owner,
+                  repo,
+                  title,
+                  body,
+                });
+                core.notice(`Created issue #${created.data.number}`);
+              }
             } else {
-              const created = await github.rest.issues.create({
-                owner,
-                repo,
-                title,
-                body,
-              });
-              core.notice(`Created issue #${created.data.number}`);
+              if (existing) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: existing.number,
+                  body,
+                  state: 'closed',
+                });
+                core.notice(`Closed issue #${existing.number} -- no fixable recommendations`);
+              } else {
+                core.notice('No fixable recommendations and no open tracking issue -- nothing to do');
+              }
             }

--- a/.github/workflows/grype-remediation-suggestions.yml
+++ b/.github/workflows/grype-remediation-suggestions.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: Optional workflow run ID to process
-        required: false
+        description: Workflow run ID from Weekly Grype Security Scan to process
+        required: true
         type: string
 
 permissions:

--- a/.github/workflows/grype-remediation-suggestions.yml
+++ b/.github/workflows/grype-remediation-suggestions.yml
@@ -26,83 +26,20 @@ jobs:
     steps:
       - name: Resolve source workflow run ID
         id: run
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.run_id }}" ]; then
-            echo "id=${{ inputs.run_id }}" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
             echo "id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
-          else
-            python - <<'PY'
-            import datetime
-            import json
-            import os
-            import urllib.parse
-            import urllib.request
-
-            token = os.environ["GH_TOKEN"]
-            repo = os.environ["REPO"]
-            workflow_name = "Weekly Grype Security Scan"
-            output_path = os.environ["GITHUB_OUTPUT"]
-
-            headers = {
-                "Accept": "application/vnd.github+json",
-                "Authorization": f"Bearer {token}",
-                "User-Agent": "ntp-dashboard-grype-remediation-suggestions",
-            }
-
-            workflows_url = f"https://api.github.com/repos/{repo}/actions/workflows"
-            workflows_req = urllib.request.Request(workflows_url, headers=headers)
-            with urllib.request.urlopen(workflows_req, timeout=30) as resp:
-                workflows = json.loads(resp.read().decode("utf-8"))
-
-            workflow_id = None
-            for workflow in workflows.get("workflows", []):
-                if workflow.get("name") == workflow_name:
-                    workflow_id = workflow["id"]
-                    break
-
-            if workflow_id is None:
-                raise SystemExit(f"Workflow not found: {workflow_name}")
-
-            def fetch_runs(extra_params=None):
-                params = {
-                    "status": "success",
-                    "per_page": 1,
-                }
-                if extra_params:
-                    params.update(extra_params)
-                runs_url = (
-                    f"https://api.github.com/repos/{repo}/actions/workflows/"
-                    f"{workflow_id}/runs?{urllib.parse.urlencode(params)}"
-                )
-                runs_req = urllib.request.Request(runs_url, headers=headers)
-                with urllib.request.urlopen(runs_req, timeout=30) as resp:
-                    return json.loads(resp.read().decode("utf-8")).get("workflow_runs", [])
-
-            # Prefer a scan that completed within the last 7 days (same-week window).
-            now = datetime.datetime.now(datetime.timezone.utc)
-            week_ago = now - datetime.timedelta(days=7)
-            created_filter = f">={week_ago.strftime('%Y-%m-%dT%H:%M:%SZ')}"
-
-            workflow_runs = fetch_runs({"created": created_filter})
-            if not workflow_runs:
-                # Fall back to the most recent successful run if none found this week.
-                workflow_runs = fetch_runs()
-
-            if not workflow_runs:
-                raise SystemExit(
-                    f"No successful runs found for workflow '{workflow_name}'"
-                )
-
-            run_id = workflow_runs[0]["id"]
-            with open(output_path, "a", encoding="utf-8") as fh:
-                fh.write(f"id={run_id}\n")
-            PY
+            exit 0
           fi
+
+          if [ -n "${{ inputs.run_id }}" ]; then
+            echo "id=${{ inputs.run_id }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "workflow_dispatch requires run_id input" >&2
+          exit 1
 
       - name: Download weekly security artifact
         env:

--- a/.github/workflows/grype-remediation-suggestions.yml
+++ b/.github/workflows/grype-remediation-suggestions.yml
@@ -18,6 +18,9 @@ permissions:
   contents: read
   issues: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   suggest-remediation:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/grype-remediation-suggestions.yml
+++ b/.github/workflows/grype-remediation-suggestions.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: Workflow run ID from Weekly Grype Security Scan to process
-        required: true
+        description: Optional workflow run ID to process
+        required: false
         type: string
 
 permissions:

--- a/.github/workflows/grype-remediation-suggestions.yml
+++ b/.github/workflows/grype-remediation-suggestions.yml
@@ -46,7 +46,6 @@ jobs:
             token = os.environ["GH_TOKEN"]
             repo = os.environ["REPO"]
             workflow_name = "Weekly Grype Security Scan"
-            branch = "pre-update-release"
             output_path = os.environ["GITHUB_OUTPUT"]
 
             headers = {
@@ -72,7 +71,6 @@ jobs:
             def fetch_runs(extra_params=None):
                 params = {
                     "status": "success",
-                    "branch": branch,
                     "per_page": 1,
                 }
                 if extra_params:
@@ -97,7 +95,7 @@ jobs:
 
             if not workflow_runs:
                 raise SystemExit(
-                    f"No successful runs found for workflow '{workflow_name}' on branch '{branch}'"
+                    f"No successful runs found for workflow '{workflow_name}'"
                 )
 
             run_id = workflow_runs[0]["id"]

--- a/.github/workflows/grype-remediation-suggestions.yml
+++ b/.github/workflows/grype-remediation-suggestions.yml
@@ -1,0 +1,298 @@
+name: Grype Remediation Suggestions
+
+on:
+  workflow_run:
+    workflows:
+      - Weekly Grype Security Scan
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Optional workflow run ID to process
+        required: false
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  suggest-remediation:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve source workflow run ID
+        id: run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.run_id }}" ]; then
+            echo "id=${{ inputs.run_id }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
+          else
+            python - <<'PY'
+            import datetime
+            import json
+            import os
+            import urllib.parse
+            import urllib.request
+
+            token = os.environ["GH_TOKEN"]
+            repo = os.environ["REPO"]
+            workflow_name = "Weekly Grype Security Scan"
+            branch = "pre-update-release"
+            output_path = os.environ["GITHUB_OUTPUT"]
+
+            headers = {
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "User-Agent": "ntp-dashboard-grype-remediation-suggestions",
+            }
+
+            workflows_url = f"https://api.github.com/repos/{repo}/actions/workflows"
+            workflows_req = urllib.request.Request(workflows_url, headers=headers)
+            with urllib.request.urlopen(workflows_req, timeout=30) as resp:
+                workflows = json.loads(resp.read().decode("utf-8"))
+
+            workflow_id = None
+            for workflow in workflows.get("workflows", []):
+                if workflow.get("name") == workflow_name:
+                    workflow_id = workflow["id"]
+                    break
+
+            if workflow_id is None:
+                raise SystemExit(f"Workflow not found: {workflow_name}")
+
+            def fetch_runs(extra_params=None):
+                params = {
+                    "status": "success",
+                    "branch": branch,
+                    "per_page": 1,
+                }
+                if extra_params:
+                    params.update(extra_params)
+                runs_url = (
+                    f"https://api.github.com/repos/{repo}/actions/workflows/"
+                    f"{workflow_id}/runs?{urllib.parse.urlencode(params)}"
+                )
+                runs_req = urllib.request.Request(runs_url, headers=headers)
+                with urllib.request.urlopen(runs_req, timeout=30) as resp:
+                    return json.loads(resp.read().decode("utf-8")).get("workflow_runs", [])
+
+            # Prefer a scan that completed within the last 7 days (same-week window).
+            now = datetime.datetime.now(datetime.timezone.utc)
+            week_ago = now - datetime.timedelta(days=7)
+            created_filter = f">={week_ago.strftime('%Y-%m-%dT%H:%M:%SZ')}"
+
+            workflow_runs = fetch_runs({"created": created_filter})
+            if not workflow_runs:
+                # Fall back to the most recent successful run if none found this week.
+                workflow_runs = fetch_runs()
+
+            if not workflow_runs:
+                raise SystemExit(
+                    f"No successful runs found for workflow '{workflow_name}' on branch '{branch}'"
+                )
+
+            run_id = workflow_runs[0]["id"]
+            with open(output_path, "a", encoding="utf-8") as fh:
+                fh.write(f"id={run_id}\n")
+            PY
+          fi
+
+      - name: Download weekly security artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ steps.run.outputs.id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+          import zipfile
+          from pathlib import Path
+
+          token = os.environ["GH_TOKEN"]
+          repo = os.environ["REPO"]
+          run_id = os.environ["RUN_ID"]
+
+          api_url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/artifacts"
+          req = urllib.request.Request(api_url, headers={
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "User-Agent": "ntp-dashboard-grype-remediation-suggestions",
+          })
+
+          with urllib.request.urlopen(req, timeout=30) as resp:
+              artifacts = json.loads(resp.read().decode("utf-8"))
+
+          selected = None
+          for art in artifacts.get("artifacts", []):
+              if art.get("name") == "weekly-security-reports" and not art.get("expired", False):
+                  selected = art
+                  break
+
+          if not selected:
+              raise SystemExit("No weekly-security-reports artifact found for the selected run")
+
+          dl_req = urllib.request.Request(selected["archive_download_url"], headers={
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "User-Agent": "ntp-dashboard-grype-remediation-suggestions",
+          })
+
+          zip_path = Path("artifact.zip")
+          with urllib.request.urlopen(dl_req, timeout=60) as resp:
+              zip_path.write_bytes(resp.read())
+
+          out_dir = Path("security-reports")
+          out_dir.mkdir(parents=True, exist_ok=True)
+
+          with zipfile.ZipFile(zip_path, "r") as zf:
+              zf.extractall(out_dir)
+          PY
+
+      - name: Build remediation recommendation report
+        id: report
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          from collections import Counter
+          from pathlib import Path
+
+          report_md = Path("security-reports/weekly-security-report.md")
+          scan_json = Path("security-reports/grype-image-local.json")
+
+          if not report_md.exists() or not scan_json.exists():
+              raise SystemExit("Expected weekly-security-report.md and grype-image-local.json in artifact")
+
+          data = json.loads(scan_json.read_text(encoding="utf-8"))
+          matches = data.get("matches", [])
+
+          severity_counts = Counter()
+          recommendations = {}
+
+          for match in matches:
+              vuln = match.get("vulnerability", {})
+              fix = vuln.get("fix", {}) or {}
+              artifact = match.get("artifact", {})
+
+              sev = vuln.get("severity", "Unknown").title()
+              severity_counts[sev] += 1
+
+              if fix.get("state") != "fixed":
+                  continue
+
+              pkg = artifact.get("name", "unknown")
+              current = artifact.get("version", "unknown")
+              fixes = fix.get("versions", [])
+              if not fixes:
+                  continue
+
+              bucket = recommendations.setdefault(pkg, {
+                  "current_versions": set(),
+                  "target_versions": set(),
+                  "severities": set(),
+              })
+              bucket["current_versions"].add(current)
+              bucket["target_versions"].update(fixes)
+              bucket["severities"].add(sev)
+
+          ordered = sorted(
+              recommendations.items(),
+              key=lambda item: (
+                  0 if "Critical" in item[1]["severities"] else 1 if "High" in item[1]["severities"] else 2,
+                  item[0],
+              ),
+          )
+
+          lines = [
+              "# Grype Remediation Suggestions",
+              "",
+              "This issue is generated automatically from the latest successful weekly Grype scan artifact.",
+              "",
+              "## Local Image Scan Snapshot",
+              "",
+              f"- Critical: {severity_counts.get('Critical', 0)}",
+              f"- High: {severity_counts.get('High', 0)}",
+              f"- Medium: {severity_counts.get('Medium', 0)}",
+              f"- Low: {severity_counts.get('Low', 0)}",
+              "",
+              "## Fixable Recommendations",
+              "",
+          ]
+
+          if not ordered:
+              lines.append("No fixable package updates were reported by Grype for the local image scan.")
+              has_recommendations = "false"
+          else:
+              lines.append("| Package | Current | Recommended target(s) | Highest severity |")
+              lines.append("|---|---|---|---|")
+              for pkg, rec in ordered:
+                  highest = "Critical" if "Critical" in rec["severities"] else "High" if "High" in rec["severities"] else "Medium" if "Medium" in rec["severities"] else "Low"
+                  current = ", ".join(sorted(rec["current_versions"]))
+                  target = ", ".join(sorted(rec["target_versions"]))
+                  lines.append(f"| {pkg} | {current} | {target} | {highest} |")
+              has_recommendations = "true"
+
+          lines.extend([
+              "",
+              "## Notes",
+              "",
+              "- Dependabot PRs should be reviewed against this recommendation set.",
+              "- The Dependabot Grype Guard workflow enforces no High/Critical regression on merge.",
+          ])
+
+          body = "\n".join(lines) + "\n"
+          Path("remediation-issue.md").write_text(body, encoding="utf-8")
+          Path("report-flags.txt").write_text(has_recommendations, encoding="utf-8")
+          PY
+
+          echo "has_recommendations=$(cat report-flags.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update remediation tracking issue
+        if: steps.report.outputs.has_recommendations == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = 'Grype remediation suggestions';
+            const body = fs.readFileSync('remediation-issue.md', 'utf8');
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const existing = issues.find(i => i.title.toLowerCase() === title.toLowerCase() && !i.pull_request);
+
+            if (existing) {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body,
+              });
+              core.notice(`Updated issue #${existing.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+              });
+              core.notice(`Created issue #${created.data.number}`);
+            }

--- a/.github/workflows/grype-remediation-suggestions.yml
+++ b/.github/workflows/grype-remediation-suggestions.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: Optional workflow run ID to process
-        required: false
+        description: Workflow run ID from Weekly Grype Security Scan to process
+        required: true
         type: string
 
 permissions:
@@ -42,58 +42,12 @@ jobs:
           exit 1
 
       - name: Download weekly security artifact
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          RUN_ID: ${{ steps.run.outputs.id }}
-        run: |
-          set -euo pipefail
-          python - <<'PY'
-          import json
-          import os
-          import urllib.request
-          import zipfile
-          from pathlib import Path
-
-          token = os.environ["GH_TOKEN"]
-          repo = os.environ["REPO"]
-          run_id = os.environ["RUN_ID"]
-
-          api_url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/artifacts"
-          req = urllib.request.Request(api_url, headers={
-              "Accept": "application/vnd.github+json",
-              "Authorization": f"Bearer {token}",
-              "User-Agent": "ntp-dashboard-grype-remediation-suggestions",
-          })
-
-          with urllib.request.urlopen(req, timeout=30) as resp:
-              artifacts = json.loads(resp.read().decode("utf-8"))
-
-          selected = None
-          for art in artifacts.get("artifacts", []):
-              if art.get("name") == "weekly-security-reports" and not art.get("expired", False):
-                  selected = art
-                  break
-
-          if not selected:
-              raise SystemExit("No weekly-security-reports artifact found for the selected run")
-
-          dl_req = urllib.request.Request(selected["archive_download_url"], headers={
-              "Accept": "application/vnd.github+json",
-              "Authorization": f"Bearer {token}",
-              "User-Agent": "ntp-dashboard-grype-remediation-suggestions",
-          })
-
-          zip_path = Path("artifact.zip")
-          with urllib.request.urlopen(dl_req, timeout=60) as resp:
-              zip_path.write_bytes(resp.read())
-
-          out_dir = Path("security-reports")
-          out_dir.mkdir(parents=True, exist_ok=True)
-
-          with zipfile.ZipFile(zip_path, "r") as zf:
-              zf.extractall(out_dir)
-          PY
+        uses: actions/download-artifact@v5
+        with:
+          name: weekly-security-reports
+          path: security-reports
+          run-id: ${{ steps.run.outputs.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build remediation recommendation report
         id: report

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM python:3.14-alpine
+FROM python:3.14.3-alpine3.22
 
 WORKDIR /app
 
 # 1. Install the default local runtime tools
 ARG INSTALL_GPSD_CLIENTS=false
 RUN set -eux; \
+	apk upgrade --no-cache; \
 	apk add --no-cache chrony; \
 	if [ "$INSTALL_GPSD_CLIENTS" = "true" ]; then \
 		apk add --no-cache gpsd-clients; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM python:3.14.3-alpine3.22
+FROM python:3.14-alpine
 
 WORKDIR /app
 
 # 1. Install the default local runtime tools
 ARG INSTALL_GPSD_CLIENTS=false
 RUN set -eux; \
-	apk upgrade --no-cache; \
 	apk add --no-cache chrony; \
 	if [ "$INSTALL_GPSD_CLIENTS" = "true" ]; then \
 		apk add --no-cache gpsd-clients; \

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Please check the [wiki](https://github.com/NightHawkATL/ntp-dashboard/wiki).
 
 # Security
 
-Please review the Security Policy for guidance on reporting vulnerabilities and checking remediation status.
+Please review the [Security Policy](https://github.com/NightHawkATL/ntp-dashboard/blob/main/SECURITY.md) for guidance on reporting vulnerabilities and checking remediation status.
 
 # Disclaimer
 **This is a current work in progress. It was coded with the help of AI to get the base project running with my ideas.**

--- a/README.md
+++ b/README.md
@@ -84,5 +84,9 @@ These are listed in no particular order
 
 Please check the [wiki](https://github.com/NightHawkATL/ntp-dashboard/wiki).
 
+# Security
+
+Please review the Security Policy for guidance on reporting vulnerabilities and checking remediation status.
+
 # Disclaimer
 **This is a current work in progress. It was coded with the help of AI to get the base project running with my ideas.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately.
+
+1. Use GitHub Private Vulnerability Reporting:
+   - https://github.com/NightHawkATL/ntp-dashboard/security/advisories/new
+2. Include as much detail as possible so the issue can be reproduced quickly:
+   - A clear description of the vulnerability
+   - Affected versions, tags, or commit SHAs
+   - Reproduction steps or proof-of-concept
+   - Impact assessment (what an attacker could do)
+   - Suggested remediation (if available)
+
+If private reporting is unavailable for any reason, open a minimal public issue asking for a secure contact path and avoid posting exploit details publicly.
+
+## Please Do Not
+
+- Do not open public issues with exploit details before a fix is available.
+- Do not run disruptive tests against systems you do not own or have explicit permission to test.
+
+## What to Expect
+
+- Initial triage acknowledgment target: within 7 days
+- Follow-up after validation: severity and remediation plan will be shared when confirmed
+- Coordinated disclosure: we will aim to publish a fix before full public details
+
+Response times may vary based on maintainer availability.
+
+## Supported Versions
+
+Security fixes are primarily targeted to:
+
+- The latest release
+- The staging branch (pre-update-release)
+- The default branch (main)
+
+Older releases may not receive backported fixes.
+
+Security remediations may be applied to pre-update-release before they are merged into main and included in a release.
+
+## Scope
+
+This policy applies to this repository and its published container images.


### PR DESCRIPTION
When Grype reported no fixable vulnerabilities, the remediation tracking issue step was skipped entirely — leaving any previously-open issue stale with outdated package targets.

## Changes

- **Removed `if: has_recommendations == 'true'` guard** — the issue step now always runs
- **Zero-recommendations path:**
  - Existing open issue → body updated to "no fixable updates" state and issue closed
  - No existing issue → logs a notice, skips creation
- **Non-zero-recommendations path** — unchanged (create or update the issue)

```yaml
if (hasRecommendations) {
  // existing create-or-update logic
} else {
  if (existing) {
    await github.rest.issues.update({ ..., state: 'closed' });
  } else {
    core.notice('No fixable recommendations and no open tracking issue -- nothing to do');
  }
}
```