### PR TITLE
Security: apply Grype remediation recommendations (refs #101)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 # 1. Install the default local runtime tools
 ARG INSTALL_GPSD_CLIENTS=false
 RUN set -eux; \
+	apk upgrade --no-cache; \
 	apk add --no-cache chrony; \
 	if [ "$INSTALL_GPSD_CLIENTS" = "true" ]; then \
 		apk add --no-cache gpsd-clients; \


### PR DESCRIPTION
Applies issue #101 remediation on pre-update-release only.

- Pin base image to python:3.14.3-alpine3.22
- Run apk upgrade during build

Refs #101