### PR TITLE
docs: add default PR template for intent clarity

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Why
+Describe the problem this PR solves and link the issue(s).
+
+## What changed
+- List the concrete changes made in this PR.
+- Keep this focused on code and config deltas.
+
+## Why this approach
+Explain the intent and tradeoffs so review automation and humans can evaluate decisions in context.
+
+## Scope
+State exactly what is in scope and what is intentionally out of scope.


### PR DESCRIPTION
Adds a repository PR template with sections for Why, What changed, Why this approach, and Scope.