### PR TITLE
Remove musl package upgrade from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN set -eux; \
 	if [ "$INSTALL_GPSD_CLIENTS" = "true" ]; then \
 		apk add --no-cache gpsd-clients; \
 	fi
+RUN apk upgrade --no-cache musl
 
 # 2. Download Tailwind CSS locally
 RUN mkdir -p /app/static && wget -q https://cdn.tailwindcss.com/ -O /app/static/tailwindcss.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN set -eux; \
 	if [ "$INSTALL_GPSD_CLIENTS" = "true" ]; then \
 		apk add --no-cache gpsd-clients; \
 	fi
-RUN apk upgrade --no-cache musl
 
 # 2. Download Tailwind CSS locally
 RUN mkdir -p /app/static && wget -q https://cdn.tailwindcss.com/ -O /app/static/tailwindcss.js


### PR DESCRIPTION
Removed the musl package upgrade command from Dockerfile.

## Why
apk upgrade --no-cache is already run earlier in the same stage (line 8), which will upgrade musl as part of upgrading installed packages. This additional RUN apk upgrade --no-cache musl is therefore redundant, adds an extra layer/network call, and can make the intent unclear. 

## What changed
- Dockerfile

## Why this approach
I was trying to fix vulnerabilities but since I reverted one from earlier, it didn't work for this.

## Scope
Hopefully to get back to a clean slate for the next release.