### PR TITLE
Change Docker image source to Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can deploy the app using the following Docker Compose:
 ```yaml
 services:
   ntp-dashboard:
-    image: ghcr.io/nighthawkatl/ntp-dashboard:latest ## -> Change to "nighthawkatl/ntp-dashboard:latest" to pull from Docker Hub.
+    image: nighthawkatl/ntp-dashboard:latest
     container_name: ntp-dashboard ## you can call it whatever you want. This is just a friendly suggestion.
     network_mode: "host" ## Required to allow direct communication with the chrony package on the host.
     environment:


### PR DESCRIPTION
Updated Docker image reference to pull from Docker Hub.

## Why
I am moving to working on everything local and will not be storing my images on GH anymore.

## What changed
- Removed the image call to pull from `ghcr.io` so that the image only pulls from Docker Hub.

## Why this approach
GitHub is becoming more and more unreliable.