### PR TITLE
Pre update release

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can deploy the app using the following Docker Compose:
 ```yaml
 services:
   ntp-dashboard:
-    image: ghcr.io/nighthawkatl/ntp-dashboard:latest ## -> Change to "nighthawkatl/ntp-dashboard:latest" to pull from Docker Hub.
+    image: nighthawkatl/ntp-dashboard:latest
     container_name: ntp-dashboard ## you can call it whatever you want. This is just a friendly suggestion.
     network_mode: "host" ## Required to allow direct communication with the chrony package on the host.
     environment:


### PR DESCRIPTION
## Why
I will no longer be storing the images on GitHub.

## What changed
- The compose was updated to only point to Docker Hub.

## Why this approach
Because GitHub is becoming unreliable.